### PR TITLE
Fix volume icon alignment with dice/coin toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -607,7 +607,7 @@
 /* Sound Toggle Button */
 .sound-toggle {
   position: absolute;
-  top: 84px;
+  top: 24px;
   left: 24px;
   z-index: 100;
   background: var(--primary-bg);


### PR DESCRIPTION
Aligned the sound toggle button with the dice/coin mode toggle by changing the top position from 84px to 24px.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)